### PR TITLE
updating to latest version of nginx:alpine, php82

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ LABEL maintainer="realJoshByrnes on Github"
 COPY ./config/openrc-gammu-smsd /etc/init.d/gammu-smsd
 
 RUN /sbin/apk update && /sbin/apk add --no-cache \
-  # Install Gammu-SMSD, PHP8, MariaDB-Client & OpenRC
-    gammu-smsd php8 php8-fpm php8-mysqli php8-mbstring \
-    php8-session php8-ctype openrc mariadb-client tzdata \
-    composer php8-intl \
+  # Install Gammu-SMSD, PHP82, MariaDB-Client & OpenRC
+    gammu-smsd php82 php82-fpm php82-mysqli php82-mbstring \
+    php82-session php82-ctype openrc mariadb-client tzdata \
+    composer php82-intl php82-simplexml \
   # Set default timezone to Australia/Sydney
   && cp /usr/share/zoneinfo/Australia/Sydney /etc/localtime \
   && echo "Australia/Sydney" >  /etc/timezone \
@@ -18,18 +18,26 @@ RUN /sbin/apk update && /sbin/apk add --no-cache \
   # Configure OpenRC
   && /bin/busybox touch /run/openrc/softlevel \
   # Get Kalkun and add to /var/www
-  && /bin/busybox wget -qO- https://github.com/kalkun-sms/Kalkun/tarball/devel | \
+  && /bin/busybox wget -qO- https://github.com/kalkun-sms/Kalkun/tarball/v0.8.2.1 | \
      /bin/busybox tar x -zvf - -C /var/www --strip-components=1 \
   # Create www user
   && /bin/busybox adduser -D -g 'www' www \
-  && /bin/busybox sed -i "s|;listen.owner\s*=\s*nobody|listen.owner = www|g" /etc/php8/php-fpm.d/www.conf \
-  && /bin/busybox sed -i "s|;listen.group\s*=\s*nobody|listen.group = www|g" /etc/php8/php-fpm.d/www.conf \
-  && /bin/busybox sed -i "s|;listen.mode\s*=\s*0660|listen.mode = 0660|g" /etc/php8/php-fpm.d/www.conf \
-  && /bin/busybox sed -i "s|user\s*=\s*nobody|user = www|g" /etc/php8/php-fpm.d/www.conf \
-  && /bin/busybox sed -i "s|group\s*=\s*nobody|group = www|g" /etc/php8/php-fpm.d/www.conf \
-  && /bin/busybox sed -i "s|;chdir\s*=\s/var/www|chdir = /var/www|g" /etc/php8/php-fpm.d/www.conf \
-  && /bin/busybox sed -i "s|;log_level\s*=\s*notice|log_level = notice|g" /etc/php8/php-fpm.conf \
+  && /bin/busybox sed -i "s|;listen.owner\s*=\s*nobody|listen.owner = www|g" /etc/php82/php-fpm.d/www.conf \
+  && /bin/busybox sed -i "s|;listen.group\s*=\s*nobody|listen.group = www|g" /etc/php82/php-fpm.d/www.conf \
+  && /bin/busybox sed -i "s|;listen.mode\s*=\s*0660|listen.mode = 0660|g" /etc/php82/php-fpm.d/www.conf \
+  && /bin/busybox sed -i "s|user\s*=\s*nobody|user = www|g" /etc/php82/php-fpm.d/www.conf \
+  && /bin/busybox sed -i "s|group\s*=\s*nobody|group = www|g" /etc/php82/php-fpm.d/www.conf \
+  && /bin/busybox sed -i "s|;chdir\s*=\s/var/www|chdir = /var/www|g" /etc/php82/php-fpm.d/www.conf \
+  && /bin/busybox sed -i "s|;log_level\s*=\s*notice|log_level = notice|g" /etc/php82/php-fpm.conf
+
+# workaround: `composer install --no-dev` tries to install dev libraries
+RUN /sbin/apk add --no-cache jq \
   && cd /var/www/ \
+  && jq 'del(."require-dev")' composer.json >composer.json_ \
+  && mv composer.json_ composer.json \
+  && rm composer.lock
+
+RUN cd /var/www/ \
   && composer install --no-dev
 
 COPY ./config/nginx.conf /etc/nginx/nginx.conf
@@ -45,7 +53,7 @@ RUN /bin/busybox chown -R www:www /var/www \
   && /bin/busybox chmod +x /var/www/scripts/daemon.sh \
   # Set auto-start
   && /sbin/rc-update add gammu-smsd default \
-  && /sbin/rc-update add php-fpm8 default \
+  && /sbin/rc-update add php-fpm82 default \
   && /sbin/rc-update add nginx default
 
 CMD ["openrc", "default"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,14 @@ version: '3.1'
 
 services:
   kalkun:
-    image: realjoshbyrnes/gammu-kalkun:0.7.1
+    image: realjoshbyrnes/gammu-kalkun:0.7.2
     restart: always
     ports:
       - 8080:80
     devices:
       - /dev/ttyUSB1:/dev/gsm-modem
+    volumes:
+      - /sys/fs/cgroup
     depends_on:
       - "kalkun-db"
 


### PR DESCRIPTION
running `docker build -t realjoshbyrnes/gammu-kalkun:dev .` fails with:
```
1.214 ERROR: unable to select packages:
1.214   php8 (no such package):
1.214     required by: world[php8]
```
because the new nginx:alpine does not support php8 (I guess).
So I updated the Dockerfile to use php82.

Also, running `docker-compose up`, failed with:
```
mkdir: can't create directory '/sys/fs/cgroup/openrc.gammu-smsd': Read-only file system
```

It works by adding a `/sys/fs/cgroup` volume on `docker-compose.yml`,
although I do not understand much about it.

However, running `docker-compose up` still fails with:
```
kalkun-db-1  | 2024-07-02  0:54:41 11 [Warning] Aborted connection 11 to db: 'kalkun' user: 'kalkun' host: '172.18.0.3' (Got an error reading communication packets)
```

Any idea about how to fix the problem?

to test:
```
docker build -t realjoshbyrnes/gammu-kalkun:0.7.2 .
docker-compose up
```
